### PR TITLE
Remove empty metadata from _titleslide.qmd

### DIFF
--- a/schedule/slides/_titleslide.qmd
+++ b/schedule/slides/_titleslide.qmd
@@ -1,6 +1,3 @@
----
----
-
 ## {{< meta lecture >}} {.large background-image="gfx/smooths.svg" background-opacity="0.3"}
 
 [Stat 406]{.secondary}


### PR DESCRIPTION
Was causing an error in `quarto render`:


```
WARN: The file /home/trevor/repos/stat406/stat-406/schedule/index.qmd contains a theme property which is being ignored. Website projects do not support per document themes since all pages within a website share the website's theme.
[ 1/48] index.qmd
[ 2/48] computing/index.qmd
[ 3/48] computing/mac_arm.qmd
[ 4/48] computing/mac_x86.qmd
[ 5/48] computing/ubuntu.qmd
[ 6/48] computing/windows.qmd
[ 7/48] syllabus.qmd
[ 8/48] course-setup.qmd
[ 9/48] schedule/index.qmd
ERROR: Error reading metadata from /home/trevor/repos/stat406/stat-406/schedule/slides/00-version-control.qmd.
end of the stream or a document separator is expected at line 6, column 11:
    [Stat 406]{.secondary}
              ^
ERROR: YAMLError: end of the stream or a document separator is expected at line 6, column 11:
    [Stat 406]{.secondary}
              ^

Stack trace:
    [Stat 406]{.secondary}
              ^
    at generateError (file:///opt/quarto/bin/quarto.js:10476:12)
    at throwError (file:///opt/quarto/bin/quarto.js:10479:11)
    at readDocument (file:///opt/quarto/bin/quarto.js:11423:16)
    at loadDocuments (file:///opt/quarto/bin/quarto.js:11444:9)
    at load (file:///opt/quarto/bin/quarto.js:11449:23)
    at parse1 (file:///opt/quarto/bin/quarto.js:11459:12)
    at parseWithNiceErrors (file:///opt/quarto/bin/quarto.js:19708:16)
    at readYamlFromMarkdown (file:///opt/quarto/bin/quarto.js:19639:17)
    at Object.target (file:///opt/quarto/bin/quarto.js:28174:24)
    at eventLoopTick (ext:core/01_core.js:153:7)
```